### PR TITLE
feat(mcp-server): enable HTTP transport alongside STDIO

### DIFF
--- a/README.md
+++ b/README.md
@@ -533,7 +533,7 @@ Executa o fluxo RAG completo (embedding + busca + contexto + LLM) no servidor MC
 
 ## Como conectar no Claude/Gemini/Codex via MCP
 
-> **Importante:** clientes MCP podem suportar diferentes transportes. Alguns preferem **STDIO** (server local executado como processo), outros suportam **HTTP/SSE**. Sempre siga a doc do cliente.
+> **Importante:** clientes MCP podem suportar diferentes transportes. O Code Compass suporta **STDIO** (processo local) e **HTTP** (endpoint JSON-RPC em `/mcp`). Alguns clientes também usam **HTTP/SSE**; sempre siga a doc do cliente.
 
 ### A) Claude (Claude Desktop)
 
@@ -577,6 +577,24 @@ env = { "MCP_SERVER_MODE" = "stdio" }
 5. usar Codex apontando para o projeto
 
 ---
+
+### Rodando em HTTP (server remoto)
+
+Use transporte HTTP quando quiser hospedar o MCP em um servidor:
+
+```bash
+pnpm -C apps/mcp-server build
+pnpm -C apps/mcp-server start:http
+```
+
+Configurações úteis:
+
+- `MCP_HTTP_HOST` (default: `0.0.0.0`)
+- `MCP_HTTP_PORT` (default: `3001`)
+- `MCP_SERVER_MODE=http` (alternativa ao `--transport http`)
+
+Endpoint MCP: `POST http://<host>:<port>/mcp` (JSON-RPC 2.0).
+
 
 ### C) Gemini (duas rotas comuns)
 

--- a/apps/mcp-server/README.md
+++ b/apps/mcp-server/README.md
@@ -1,6 +1,6 @@
 # MCP Server (`apps/mcp-server`)
 
-Servidor MCP em NestJS com transporte `stdio` (NDJSON) e tools `search_code`, `open_file` e `ask_code`.
+Servidor MCP em NestJS com transporte `stdio` (NDJSON/LSP) e `http` (JSON-RPC em `/mcp`) com tools `search_code`, `open_file` e `ask_code`.
 
 ## Rodando
 
@@ -14,6 +14,18 @@ Modo dev:
 ```bash
 pnpm -C apps/mcp-server mcp:dev
 ```
+
+Modo HTTP:
+
+```bash
+pnpm -C apps/mcp-server start:http
+```
+
+Variáveis HTTP:
+
+- `MCP_HTTP_HOST` (default `0.0.0.0`)
+- `MCP_HTTP_PORT` (default `3001`)
+- `MCP_SERVER_MODE=http` (alternativa ao `--transport http`)
 
 ## Protocolo STDIO (NDJSON)
 

--- a/apps/mcp-server/scripts/test-stdio-open-file.ts
+++ b/apps/mcp-server/scripts/test-stdio-open-file.ts
@@ -3,6 +3,7 @@ import { rmSync } from 'node:fs';
 import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 
+import { McpProtocolHandler } from '../src/mcp-protocol.handler';
 import { McpStdioServer } from '../src/mcp-stdio.server';
 import { OpenFileTool } from '../src/open-file.tool';
 import { SearchCodeTool } from '../src/search-code.tool';
@@ -16,7 +17,8 @@ function createServer(): McpStdioServer {
   const fileService = new FileService();
   const openFileTool = new OpenFileTool(fileService);
   const askCodeTool = new AskCodeTool(searchCodeTool, openFileTool);
-  return new McpStdioServer(searchCodeTool, openFileTool, askCodeTool);
+  const protocolHandler = new McpProtocolHandler(searchCodeTool, openFileTool, askCodeTool);
+  return new McpStdioServer(protocolHandler);
 }
 
 async function run(): Promise<void> {

--- a/apps/mcp-server/scripts/test-stdio-search-code.ts
+++ b/apps/mcp-server/scripts/test-stdio-search-code.ts
@@ -1,3 +1,4 @@
+import { McpProtocolHandler } from '../src/mcp-protocol.handler';
 import { McpStdioServer } from '../src/mcp-stdio.server';
 import { OpenFileTool } from '../src/open-file.tool';
 import { SearchCodeTool } from '../src/search-code.tool';
@@ -11,7 +12,8 @@ function createServer(): McpStdioServer {
   const fileService = new FileService();
   const openFileTool = new OpenFileTool(fileService);
   const askCodeTool = new AskCodeTool(searchCodeTool, openFileTool);
-  return new McpStdioServer(searchCodeTool, openFileTool, askCodeTool);
+  const protocolHandler = new McpProtocolHandler(searchCodeTool, openFileTool, askCodeTool);
+  return new McpStdioServer(protocolHandler);
 }
 
 async function run(): Promise<void> {

--- a/apps/mcp-server/src/app.module.ts
+++ b/apps/mcp-server/src/app.module.ts
@@ -1,19 +1,23 @@
 import { Module } from '@nestjs/common';
 
+import { AskCodeTool } from './ask-code.tool';
 import { FileService } from './file.service';
+import { McpHttpController } from './mcp-http.controller';
+import { McpProtocolHandler } from './mcp-protocol.handler';
 import { McpStdioServer } from './mcp-stdio.server';
 import { OpenFileTool } from './open-file.tool';
 import { QdrantService } from './qdrant.service';
-import { AskCodeTool } from './ask-code.tool';
 import { SearchCodeTool } from './search-code.tool';
 
 @Module({
+  controllers: [McpHttpController],
   providers: [
     QdrantService,
     SearchCodeTool,
     FileService,
     OpenFileTool,
     AskCodeTool,
+    McpProtocolHandler,
     McpStdioServer,
   ],
 })

--- a/apps/mcp-server/src/main.ts
+++ b/apps/mcp-server/src/main.ts
@@ -5,32 +5,35 @@ import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import { loadMcpEnvFiles } from './env-loader';
 import { McpStdioServer } from './mcp-stdio.server';
-
-function resolveTransport(argv: string[]): 'stdio' | 'http' {
-  const transportIndex = argv.findIndex((arg) => arg === '--transport');
-  if (transportIndex >= 0 && argv[transportIndex + 1] === 'http') {
-    return 'http';
-  }
-  return 'stdio';
-}
+import { resolveHttpHost, resolveHttpPort, resolveTransport } from './transport';
 
 async function bootstrap(): Promise<void> {
   loadMcpEnvFiles();
 
-  const transport = resolveTransport(process.argv.slice(2));
-
-  const app = await NestFactory.createApplicationContext(AppModule, {
-    logger: ['error', 'warn'],
+  const transport = resolveTransport({
+    argv: process.argv.slice(2),
+    env: process.env,
   });
 
   if (transport === 'stdio') {
+    const app = await NestFactory.createApplicationContext(AppModule, {
+      logger: ['error', 'warn'],
+    });
+
     const stdioServer = app.get(McpStdioServer);
     stdioServer.run();
     return;
   }
 
-  process.stderr.write('Transport HTTP selecionado; encerrando sem iniciar servidor HTTP.\n');
-  await app.close();
+  const app = await NestFactory.create(AppModule, {
+    logger: ['error', 'warn'],
+  });
+
+  const host = resolveHttpHost(process.env);
+  const port = resolveHttpPort(process.env);
+
+  await app.listen(port, host);
+  process.stderr.write(`[mcp] HTTP escutando em http://${host}:${port}/mcp\n`);
 }
 
 bootstrap().catch((error: unknown) => {

--- a/apps/mcp-server/src/mcp-http.controller.ts
+++ b/apps/mcp-server/src/mcp-http.controller.ts
@@ -1,0 +1,29 @@
+import { Body, Controller, HttpCode, HttpStatus, Post, Res } from '@nestjs/common';
+import { McpProtocolHandler } from './mcp-protocol.handler';
+
+@Controller('mcp')
+export class McpHttpController {
+  constructor(private readonly protocolHandler: McpProtocolHandler) {}
+
+  @Post()
+  @HttpCode(HttpStatus.OK)
+  async handle(@Body() body: unknown, @Res() response: any): Promise<Response> {
+    if (!this.protocolHandler.isMcpRequest(body)) {
+      return response.status(HttpStatus.BAD_REQUEST).json({
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32600,
+          message: 'Request inválido para protocolo MCP.',
+        },
+      });
+    }
+
+    const result = await this.protocolHandler.handleMcpRequest(body);
+    if (!result) {
+      return response.status(HttpStatus.NO_CONTENT).send();
+    }
+
+    return response.status(HttpStatus.OK).json(result);
+  }
+}

--- a/apps/mcp-server/src/mcp-protocol.handler.ts
+++ b/apps/mcp-server/src/mcp-protocol.handler.ts
@@ -1,0 +1,292 @@
+import { Injectable } from '@nestjs/common';
+
+import { ToolExecutionError, ToolInputError } from './errors';
+import { AskCodeTool } from './ask-code.tool';
+import { OpenFileTool } from './open-file.tool';
+import { SearchCodeTool } from './search-code.tool';
+import { StdioToolOutput, StdioToolRequest } from './types';
+
+export type McpJsonRpcId = string | number | null;
+
+export interface McpJsonRpcRequest {
+  jsonrpc: '2.0';
+  id?: McpJsonRpcId;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface McpJsonRpcResponse {
+  jsonrpc: '2.0';
+  id: McpJsonRpcId;
+  result?: Record<string, unknown>;
+  error?: {
+    code: number;
+    message: string;
+  };
+}
+
+interface McpToolDescriptor {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+}
+
+@Injectable()
+export class McpProtocolHandler {
+  constructor(
+    private readonly searchCodeTool: SearchCodeTool,
+    private readonly openFileTool: OpenFileTool,
+    private readonly askCodeTool: AskCodeTool,
+  ) {}
+
+  isMcpRequest(parsed: unknown): parsed is McpJsonRpcRequest {
+    if (!parsed || typeof parsed !== 'object') {
+      return false;
+    }
+    const request = parsed as McpJsonRpcRequest;
+    return request.jsonrpc === '2.0' && typeof request.method === 'string';
+  }
+
+  async handleMcpRequest(request: McpJsonRpcRequest): Promise<McpJsonRpcResponse | undefined> {
+    const id = request.id ?? null;
+
+    if (request.method === 'initialize') {
+      return this.response(id, {
+        protocolVersion: '2024-11-05',
+        capabilities: {
+          tools: {
+            listChanged: true,
+          },
+        },
+        serverInfo: {
+          name: 'code-compass',
+          version: '0.1.0',
+        },
+      });
+    }
+
+    if (request.method === 'initialized') {
+      return undefined;
+    }
+
+    if (request.method === 'tools/list') {
+      return this.response(id, {
+        tools: this.describeTools(),
+      });
+    }
+
+    if (request.method === 'tools/call') {
+      const params = (request.params ?? {}) as Record<string, unknown>;
+      const name = typeof params.name === 'string' ? params.name : '';
+      const args = (params.arguments ?? {}) as Record<string, unknown>;
+
+      if (!name) {
+        return this.error(id, -32602, 'Campo "name" é obrigatório em tools/call');
+      }
+
+      try {
+        const output = await this.dispatchTool({
+          id: 'mcp',
+          tool: name,
+          input: args,
+        });
+
+        return this.response(id, {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(output),
+            },
+          ],
+        });
+      } catch (error) {
+        if (error instanceof ToolInputError || error instanceof ToolExecutionError) {
+          return this.response(id, {
+            isError: true,
+            content: [
+              {
+                type: 'text',
+                text: error.message,
+              },
+            ],
+          });
+        }
+
+        return this.response(id, {
+          isError: true,
+          content: [
+            {
+              type: 'text',
+              text: 'Erro interno ao executar tool',
+            },
+          ],
+        });
+      }
+    }
+
+    if (id === null) {
+      return undefined;
+    }
+
+    return this.error(id, -32601, `Método não suportado: ${request.method}`);
+  }
+
+  async dispatchTool(request: StdioToolRequest): Promise<StdioToolOutput> {
+    if (request.tool === 'search_code') {
+      return this.searchCodeTool.execute(request.input);
+    }
+
+    if (request.tool === 'open_file') {
+      return this.openFileTool.execute(request.input);
+    }
+
+    if (request.tool === 'ask_code') {
+      return this.askCodeTool.execute(request.input);
+    }
+
+    throw new ToolExecutionError('BAD_REQUEST', `Tool não suportada: ${request.tool}`);
+  }
+
+  private describeTools(): McpToolDescriptor[] {
+    return [
+      {
+        name: 'search_code',
+        description: 'Busca semântica por trechos de código com evidência (path + linhas).',
+        inputSchema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['query'],
+          anyOf: [{ required: ['repo'] }, { required: ['scope'] }],
+          properties: {
+            repo: { type: 'string' },
+            scope: {
+              oneOf: [
+                {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['type', 'repo'],
+                  properties: {
+                    type: { const: 'repo' },
+                    repo: { type: 'string' },
+                  },
+                },
+                {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['type', 'repos'],
+                  properties: {
+                    type: { const: 'repos' },
+                    repos: {
+                      type: 'array',
+                      items: { type: 'string' },
+                    },
+                  },
+                },
+                {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['type'],
+                  properties: {
+                    type: { const: 'all' },
+                  },
+                },
+              ],
+            },
+            query: { type: 'string' },
+            topK: { type: 'number' },
+            pathPrefix: { type: 'string' },
+            vector: { type: 'array', items: { type: 'number' } },
+          },
+        },
+      },
+      {
+        name: 'open_file',
+        description: 'Abre trecho de arquivo local com allowlist e limites de tamanho.',
+        inputSchema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['repo', 'path'],
+          properties: {
+            repo: { type: 'string' },
+            path: { type: 'string' },
+            startLine: { type: 'number' },
+            endLine: { type: 'number' },
+            maxBytes: { type: 'number' },
+          },
+        },
+      },
+      {
+        name: 'ask_code',
+        description: 'Executa RAG completo (embed + busca + contexto + LLM) com política centralizada.',
+        inputSchema: {
+          type: 'object',
+          additionalProperties: false,
+          required: ['query'],
+          anyOf: [{ required: ['repo'] }, { required: ['scope'] }],
+          properties: {
+            repo: { type: 'string' },
+            scope: {
+              oneOf: [
+                {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['type', 'repo'],
+                  properties: {
+                    type: { const: 'repo' },
+                    repo: { type: 'string' },
+                  },
+                },
+                {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['type', 'repos'],
+                  properties: {
+                    type: { const: 'repos' },
+                    repos: {
+                      type: 'array',
+                      items: { type: 'string' },
+                    },
+                  },
+                },
+                {
+                  type: 'object',
+                  additionalProperties: false,
+                  required: ['type'],
+                  properties: {
+                    type: { const: 'all' },
+                  },
+                },
+              ],
+            },
+            query: { type: 'string' },
+            topK: { type: 'number' },
+            pathPrefix: { type: 'string' },
+            language: { type: 'string' },
+            minScore: { type: 'number' },
+            llmModel: { type: 'string' },
+            grounded: { type: 'boolean' },
+          },
+        },
+      },
+    ];
+  }
+
+  private response(id: McpJsonRpcId, result: Record<string, unknown>): McpJsonRpcResponse {
+    return {
+      jsonrpc: '2.0',
+      id,
+      result,
+    };
+  }
+
+  private error(id: McpJsonRpcId, code: number, message: string): McpJsonRpcResponse {
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code,
+        message,
+      },
+    };
+  }
+}

--- a/apps/mcp-server/src/transport.ts
+++ b/apps/mcp-server/src/transport.ts
@@ -1,0 +1,32 @@
+export type McpTransport = 'stdio' | 'http';
+
+interface ResolveTransportInput {
+  argv: string[];
+  env: NodeJS.ProcessEnv;
+}
+
+export function resolveTransport(input: ResolveTransportInput): McpTransport {
+  const transportIndex = input.argv.findIndex((arg) => arg === '--transport');
+  if (transportIndex >= 0) {
+    return input.argv[transportIndex + 1] === 'http' ? 'http' : 'stdio';
+  }
+
+  if (input.env.MCP_SERVER_MODE === 'http') {
+    return 'http';
+  }
+
+  return 'stdio';
+}
+
+export function resolveHttpPort(env: NodeJS.ProcessEnv): number {
+  const raw = env.MCP_HTTP_PORT ?? env.PORT;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) {
+    return 3001;
+  }
+  return parsed;
+}
+
+export function resolveHttpHost(env: NodeJS.ProcessEnv): string {
+  return env.MCP_HTTP_HOST || '0.0.0.0';
+}

--- a/apps/mcp-server/test/mcp-http.controller.spec.ts
+++ b/apps/mcp-server/test/mcp-http.controller.spec.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest';
+
+import { AskCodeTool } from '../src/ask-code.tool';
+import { McpHttpController } from '../src/mcp-http.controller';
+import { McpProtocolHandler } from '../src/mcp-protocol.handler';
+import { OpenFileTool } from '../src/open-file.tool';
+import { QdrantService } from '../src/qdrant.service';
+import { SearchCodeTool } from '../src/search-code.tool';
+
+function createController(): McpHttpController {
+  const qdrantService = new QdrantService();
+  const searchCodeTool = new SearchCodeTool(qdrantService);
+  const openFileTool = {
+    execute: async () => ({
+      path: 'README.md',
+      startLine: 1,
+      endLine: 1,
+      totalLines: 1,
+      text: '',
+      truncated: false,
+    }),
+  } as unknown as OpenFileTool;
+  const askCodeTool = new AskCodeTool(searchCodeTool, openFileTool);
+  const protocolHandler = new McpProtocolHandler(searchCodeTool, openFileTool, askCodeTool);
+  return new McpHttpController(protocolHandler);
+}
+
+function createResponseSink() {
+  return {
+    statusCode: 200,
+    payload: undefined as unknown,
+    status(code: number) {
+      this.statusCode = code;
+      return this;
+    },
+    json(data: unknown) {
+      this.payload = data;
+      return this;
+    },
+    send() {
+      this.payload = undefined;
+      return this;
+    },
+  };
+}
+
+describe('McpHttpController', () => {
+  it('deve retornar erro -32600 para payload inválido', async () => {
+    const controller = createController();
+    const res = createResponseSink();
+
+    await controller.handle({ invalid: true }, res as never);
+
+    expect(res.statusCode).toBe(400);
+    expect((res.payload as { error: { code: number } }).error.code).toBe(-32600);
+  });
+
+  it('deve responder initialize via HTTP', async () => {
+    const controller = createController();
+    const res = createResponseSink();
+
+    await controller.handle(
+      {
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {},
+      },
+      res as never,
+    );
+
+    expect(res.statusCode).toBe(200);
+    expect((res.payload as { result: { protocolVersion: string } }).result.protocolVersion).toBe(
+      '2024-11-05',
+    );
+  });
+});

--- a/apps/mcp-server/test/stdio-harness.spec.ts
+++ b/apps/mcp-server/test/stdio-harness.spec.ts
@@ -6,6 +6,7 @@ import { tmpdir } from 'node:os';
 import { afterEach, describe, expect, it } from 'vitest';
 
 import { FileService } from '../src/file.service';
+import { McpProtocolHandler } from '../src/mcp-protocol.handler';
 import { McpStdioServer } from '../src/mcp-stdio.server';
 import { OpenFileTool } from '../src/open-file.tool';
 import { QdrantService } from '../src/qdrant.service';
@@ -35,7 +36,8 @@ function createServer(): McpStdioServer {
   const fileService = new FileService();
   const openFileTool = new OpenFileTool(fileService);
   const askCodeTool = new AskCodeTool(searchCodeTool, openFileTool);
-  return new McpStdioServer(searchCodeTool, openFileTool, askCodeTool);
+  const protocolHandler = new McpProtocolHandler(searchCodeTool, openFileTool, askCodeTool);
+  return new McpStdioServer(protocolHandler);
 }
 
 describe('MCP stdio harness', () => {

--- a/apps/mcp-server/test/transport.spec.ts
+++ b/apps/mcp-server/test/transport.spec.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { resolveHttpHost, resolveHttpPort, resolveTransport } from '../src/transport';
+
+describe('transport resolver', () => {
+  it('deve priorizar flag --transport http', () => {
+    expect(resolveTransport({ argv: ['--transport', 'http'], env: {} })).toBe('http');
+  });
+
+  it('deve aceitar MCP_SERVER_MODE=http sem flag', () => {
+    expect(resolveTransport({ argv: [], env: { MCP_SERVER_MODE: 'http' } })).toBe('http');
+  });
+
+  it('deve manter stdio como default', () => {
+    expect(resolveTransport({ argv: [], env: {} })).toBe('stdio');
+  });
+
+  it('deve resolver porta e host HTTP com defaults seguros', () => {
+    expect(resolveHttpPort({})).toBe(3001);
+    expect(resolveHttpHost({})).toBe('0.0.0.0');
+    expect(resolveHttpPort({ MCP_HTTP_PORT: '4010' })).toBe(4010);
+    expect(resolveHttpHost({ MCP_HTTP_HOST: '127.0.0.1' })).toBe('127.0.0.1');
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,31 +8,6 @@ importers:
 
   .: {}
 
-  apps/cli:
-    dependencies:
-      commander:
-        specifier: ^12.1.0
-        version: 12.1.0
-      ink:
-        specifier: ^4.4.1
-        version: 4.4.1(@types/react@18.3.28)(react@18.3.1)
-      react:
-        specifier: ^18.3.1
-        version: 18.3.1
-    devDependencies:
-      '@types/node':
-        specifier: ^22.13.1
-        version: 22.19.10
-      '@types/react':
-        specifier: ^18.2.76
-        version: 18.3.28
-      tsx:
-        specifier: ^4.19.2
-        version: 4.21.0
-      typescript:
-        specifier: ^5.7.3
-        version: 5.9.3
-
   apps/docs:
     dependencies:
       next:
@@ -102,10 +77,6 @@ importers:
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.19.10)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.2)
 
 packages:
-
-  '@alcalzone/ansi-tokenize@0.1.3':
-    resolution: {integrity: sha512-3yWxPTq3UQ/FY9p1ErPxIyfT64elWaMvM9lIHnaqpyft63tkxodF5aUElYHrdisWve5cETkh1+KBw1yJuW0aRw==}
-    engines: {node: '>=14.13.1'}
 
   '@angular-devkit/core@17.3.11':
     resolution: {integrity: sha512-vTNDYNsLIWpYk2I969LMQFH29GTsLzxNk/0cLw5q56ARF0v5sIWfHYwGTS88jdDqIpuuettcSczbxeA7EuAmqQ==}
@@ -1145,10 +1116,6 @@ packages:
     resolution: {integrity: sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==}
     engines: {node: '>=8'}
 
-  ansi-escapes@6.2.1:
-    resolution: {integrity: sha512-4nJ3yixlEthEJ9Rk4vPcdBRkZvQZlYyu8j4/Mqz5sgIkddmEnH2Yj2ZrnP9S3tQOvSNRUIgVNF/1yPpRAGNRig==}
-    engines: {node: '>=14.16'}
-
   ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
@@ -1200,10 +1167,6 @@ packages:
 
   asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-
-  auto-bind@5.0.1:
-    resolution: {integrity: sha512-ooviqdwwgfIfNmDwo94wlshcdzfO64XV0Cg6oDsDYBJfITDz1EngD2z7DkbvCWn+XIMsIqW27sEVF6qcpJrRcg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   axios@1.13.5:
     resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
@@ -1339,21 +1302,9 @@ packages:
     resolution: {integrity: sha512-rNjApaLzuwaOTjCiT8lSDdGN1APCiqkChLMJxJPWLunPAt5fy8xgU9/jNOchV84wfIxrA0lRQB7oCT8jrn/wrQ==}
     engines: {node: '>=6.0'}
 
-  ci-info@3.9.0:
-    resolution: {integrity: sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==}
-    engines: {node: '>=8'}
-
-  cli-boxes@3.0.0:
-    resolution: {integrity: sha512-/lzGpEWL/8PfI0BmBOPRwp0c/wFNX1RdUML3jK/RcSBA9T8mZDdQpqYBKtCFTOfQbwPqWEOpjqW+Fnayc0969g==}
-    engines: {node: '>=10'}
-
   cli-cursor@3.1.0:
     resolution: {integrity: sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==}
     engines: {node: '>=8'}
-
-  cli-cursor@4.0.0:
-    resolution: {integrity: sha512-VGtlMu3x/4DOtIUwEkRezxUZ2lBacNJCHash0N0WeZDBS+7Ux1dm3XWAgWYxLJFMMdOeXMHXorshEFhbMSGelg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cli-spinners@2.9.2:
     resolution: {integrity: sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==}
@@ -1362,10 +1313,6 @@ packages:
   cli-table3@0.6.5:
     resolution: {integrity: sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==}
     engines: {node: 10.* || >= 12.*}
-
-  cli-truncate@3.1.0:
-    resolution: {integrity: sha512-wfOBkjXteqSnI59oPcJkcPl/ZmwvMMOj340qUIY1SKZCv0B9Cf4D4fAucRkIKQmsIuYK3x1rrgU7MeGRruiuiA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cli-width@3.0.0:
     resolution: {integrity: sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==}
@@ -1390,10 +1337,6 @@ packages:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
 
-  code-excerpt@4.0.0:
-    resolution: {integrity: sha512-xxodCmBen3iy2i0WtAK8FlFNrRzjUqjRsMfho58xT/wvZU1YTM3fCnRjcy1gJPMepaRlgm/0e6w8SpWHpn3/cA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -1410,10 +1353,6 @@ packages:
 
   comma-separated-tokens@2.0.3:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
-
-  commander@12.1.0:
-    resolution: {integrity: sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==}
-    engines: {node: '>=18'}
 
   commander@13.1.0:
     resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
@@ -1461,10 +1400,6 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
-
-  convert-to-spaces@2.0.1:
-    resolution: {integrity: sha512-rcQ1bsQO9799wq24uE5AM2tAILy4gXGIK/njFWcVQkGNZ96edlpY+A7bjwvzjYvLDyzmG1MmMLZhpcsb+klNMQ==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   cookie-signature@1.0.7:
     resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
@@ -1799,10 +1734,6 @@ packages:
     resolution: {integrity: sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==}
     engines: {node: '>=0.8.0'}
 
-  escape-string-regexp@2.0.0:
-    resolution: {integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==}
-    engines: {node: '>=8'}
-
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
@@ -2124,25 +2055,8 @@ packages:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
 
-  indent-string@5.0.0:
-    resolution: {integrity: sha512-m6FAo/spmsW2Ab2fU35JTYwtOKa2yAwXSwgjSv1TJzh4Mh7mC3lzAOVLBprb72XsTrgkEIsl7YrFNAiDiRhIGg==}
-    engines: {node: '>=12'}
-
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
-
-  ink@4.4.1:
-    resolution: {integrity: sha512-rXckvqPBB0Krifk5rn/5LvQGmyXwCUpBfmTwbkQNBY9JY8RSl3b8OftBNEYxg4+SWUhEKcPifgope28uL9inlA==}
-    engines: {node: '>=14.16'}
-    peerDependencies:
-      '@types/react': '>=18.0.0'
-      react: '>=18.0.0'
-      react-devtools-core: ^4.19.1
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      react-devtools-core:
-        optional: true
 
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
@@ -2179,10 +2093,6 @@ packages:
     resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
     engines: {node: '>=8'}
 
-  is-ci@3.0.1:
-    resolution: {integrity: sha512-ZYvCgrefwqoQ6yTyYUbQu64HsITZ3NfKX1lzaEYdkTDcfKzzCI/wthRRYKkdjHKFVgNiXKAKm65Zo1pk2as/QQ==}
-    hasBin: true
-
   is-decimal@2.0.1:
     resolution: {integrity: sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==}
 
@@ -2203,10 +2113,6 @@ packages:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
 
-  is-fullwidth-code-point@4.0.0:
-    resolution: {integrity: sha512-O4L094N2/dZ7xqVdrXhh9r1KODPJpFms8B5sGdJLPy664AgvXsreZUyCQQNItZRDlYug4xStLjNp/sz3HvBowQ==}
-    engines: {node: '>=12'}
-
   is-glob@4.0.3:
     resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
     engines: {node: '>=0.10.0'}
@@ -2222,9 +2128,6 @@ packages:
   is-interactive@1.0.0:
     resolution: {integrity: sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==}
     engines: {node: '>=8'}
-
-  is-lower-case@2.0.2:
-    resolution: {integrity: sha512-bVcMJy4X5Og6VZfdOZstSexlEy20Sr0k/p/b2IlQJlfdKAQuMpiv5w2Ccxb8sKdRUNAG1PnHVHjFSdRDVS6NlQ==}
 
   is-node-process@1.2.0:
     resolution: {integrity: sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==}
@@ -2244,9 +2147,6 @@ packages:
   is-unicode-supported@0.1.0:
     resolution: {integrity: sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==}
     engines: {node: '>=10'}
-
-  is-upper-case@2.0.2:
-    resolution: {integrity: sha512-44pxmxAvnnAOwBg4tHPnkfvgjPwbc5QIsSstNU+YcJ1ovxVzCWpSGosPJOZh/a1tdl81fbgnLc9LLv+x2ywbPQ==}
 
   is-wsl@3.1.0:
     resolution: {integrity: sha512-UcVfVfaK4Sc4m7X3dUSoHoozQGBEFeDC+zVo06t98xe8CzHSZZBekNXH+tu0NalHolcJ/QAGqS46Hef7QXBIMw==}
@@ -2803,10 +2703,6 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
-  patch-console@2.0.0:
-    resolution: {integrity: sha512-0YNdUceMdaQwoKce1gatDScmMo5pu/tfABfnzEqeG0gtTmd7mh/WcwgUjtAeOU7N8nFFlbQBnFK2gXW5fGvmMA==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
-
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -2919,12 +2815,6 @@ packages:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
       react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
-  react-reconciler@0.29.2:
-    resolution: {integrity: sha512-zZQqIiYgDCTP/f1N/mAR10nJGrPD2ZR+jDSEsKWJHYC7Cm2wodlwbR3upZRdC3cjIjSlTLNVyO7Iu0Yy7t2AYg==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      react: ^18.3.1
-
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -3030,10 +2920,6 @@ packages:
   restore-cursor@3.1.0:
     resolution: {integrity: sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==}
     engines: {node: '>=8'}
-
-  restore-cursor@4.0.0:
-    resolution: {integrity: sha512-I9fPXU9geO9bHOt9pHHOhOkYerIMsmVaWB0rA2AI9ERh/+x/i7MV5HKBNrg+ljO5eoPVgCcnFuRjJ9uH6I/3eg==}
-    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
 
   retext-latin@4.0.0:
     resolution: {integrity: sha512-hv9woG7Fy0M9IlRQloq/N6atV82NxLGveq+3H2WOi79dtIYWN8OaxogDm77f8YnVXJL2VD3bbqowu5E3EMhBYA==}
@@ -3163,14 +3049,6 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  slice-ansi@5.0.0:
-    resolution: {integrity: sha512-FC+lgizVPfie0kkhqUScwRu1O/lF6NOgJmlCgK+/LYxDCTk8sGelYaHDhFcDN+Sn3Cv+3VSa4Byeo+IMCzpMgQ==}
-    engines: {node: '>=12'}
-
-  slice-ansi@6.0.0:
-    resolution: {integrity: sha512-6bn4hRfkTvDfUoEQYkERg0BVF1D0vrX9HEkMl08uDiNWvVvjylLHvZFZWkDo6wjT8tUctbYl1nCOuE66ZTaUtA==}
-    engines: {node: '>=14.16'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3195,10 +3073,6 @@ packages:
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
-
-  stack-utils@2.0.6:
-    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
-    engines: {node: '>=10'}
 
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
@@ -3413,10 +3287,6 @@ packages:
     resolution: {integrity: sha512-tEHPASMqi7kqwfJbkk7hc/4EhlrKCSLcur+TcvYki3vhIfaRMXnXjaYFgXpoZRbT6GdprD4tGuVBEmTpUgLBsw==}
     peerDependencies:
       typescript: '*'
-
-  type-fest@0.12.0:
-    resolution: {integrity: sha512-53RyidyjvkGpnWPMF9bQgFtWp+Sl8O2Rp13VavmJgfAP9WWG6q6TkrKU8iyJdnwnfgHI6k2hTlgqH4aSdjoTbg==}
-    engines: {node: '>=10'}
 
   type-fest@0.21.3:
     resolution: {integrity: sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==}
@@ -3684,10 +3554,6 @@ packages:
   wicked-good-xpath@1.3.0:
     resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
 
-  widest-line@4.0.1:
-    resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
-    engines: {node: '>=12'}
-
   wrap-ansi@6.2.0:
     resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
     engines: {node: '>=8'}
@@ -3699,18 +3565,6 @@ packages:
   wrap-ansi@8.1.0:
     resolution: {integrity: sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==}
     engines: {node: '>=12'}
-
-  ws@8.19.0:
-    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -3729,9 +3583,6 @@ packages:
     resolution: {integrity: sha512-4LCcse/U2MHZ63HAJVE+v71o7yOdIe4cZ70Wpf8D/IyjDKYQLV5GD46B+hSTjJsvV5PztjvHoU580EftxjDZFQ==}
     engines: {node: '>=12.20'}
 
-  yoga-wasm-web@0.3.3:
-    resolution: {integrity: sha512-N+d4UJSJbt/R3wqY7Coqs5pcV0aUj2j9IaQ3rNj9bVCLld8tTGKRa2USARjnvZJWVx1NDmQev8EknoczaOQDOA==}
-
   zod-validation-error@3.5.4:
     resolution: {integrity: sha512-+hEiRIiPobgyuFlEojnqjJnhFvg4r/i3cqgcm67eehZf/WBaK3g6cD02YU9mtdVxZjv8CzCA9n/Rhrs3yAAvAw==}
     engines: {node: '>=18.0.0'}
@@ -3745,11 +3596,6 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
-
-  '@alcalzone/ansi-tokenize@0.1.3':
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 4.0.0
 
   '@angular-devkit/core@17.3.11(chokidar@3.6.0)':
     dependencies:
@@ -4804,8 +4650,6 @@ snapshots:
     dependencies:
       type-fest: 0.21.3
 
-  ansi-escapes@6.2.1: {}
-
   ansi-regex@5.0.1: {}
 
   ansi-regex@6.2.2: {}
@@ -4842,8 +4686,6 @@ snapshots:
   astring@1.9.0: {}
 
   asynckit@0.4.0: {}
-
-  auto-bind@5.0.1: {}
 
   axios@1.13.5:
     dependencies:
@@ -5005,17 +4847,9 @@ snapshots:
 
   chrome-trace-event@1.0.4: {}
 
-  ci-info@3.9.0: {}
-
-  cli-boxes@3.0.0: {}
-
   cli-cursor@3.1.0:
     dependencies:
       restore-cursor: 3.1.0
-
-  cli-cursor@4.0.0:
-    dependencies:
-      restore-cursor: 4.0.0
 
   cli-spinners@2.9.2: {}
 
@@ -5024,11 +4858,6 @@ snapshots:
       string-width: 4.2.3
     optionalDependencies:
       '@colors/colors': 1.5.0
-
-  cli-truncate@3.1.0:
-    dependencies:
-      slice-ansi: 5.0.0
-      string-width: 5.1.2
 
   cli-width@3.0.0: {}
 
@@ -5046,10 +4875,6 @@ snapshots:
 
   clsx@2.1.1: {}
 
-  code-excerpt@4.0.0:
-    dependencies:
-      convert-to-spaces: 2.0.1
-
   collapse-white-space@2.1.0: {}
 
   color-convert@2.0.1:
@@ -5063,8 +4888,6 @@ snapshots:
       delayed-stream: 1.0.0
 
   comma-separated-tokens@2.0.3: {}
-
-  commander@12.1.0: {}
 
   commander@13.1.0: {}
 
@@ -5104,8 +4927,6 @@ snapshots:
       safe-buffer: 5.2.1
 
   content-type@1.0.5: {}
-
-  convert-to-spaces@2.0.1: {}
 
   cookie-signature@1.0.7: {}
 
@@ -5472,8 +5293,6 @@ snapshots:
 
   escape-string-regexp@1.0.5: {}
 
-  escape-string-regexp@2.0.0: {}
-
   escape-string-regexp@5.0.0: {}
 
   eslint-scope@5.1.1:
@@ -5721,6 +5540,7 @@ snapshots:
   get-tsconfig@4.13.6:
     dependencies:
       resolve-pkg-maps: 1.0.0
+    optional: true
 
   github-slugger@2.0.0: {}
 
@@ -5942,43 +5762,7 @@ snapshots:
       parent-module: 1.0.1
       resolve-from: 4.0.0
 
-  indent-string@5.0.0: {}
-
   inherits@2.0.4: {}
-
-  ink@4.4.1(@types/react@18.3.28)(react@18.3.1):
-    dependencies:
-      '@alcalzone/ansi-tokenize': 0.1.3
-      ansi-escapes: 6.2.1
-      auto-bind: 5.0.1
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      cli-cursor: 4.0.0
-      cli-truncate: 3.1.0
-      code-excerpt: 4.0.0
-      indent-string: 5.0.0
-      is-ci: 3.0.1
-      is-lower-case: 2.0.2
-      is-upper-case: 2.0.2
-      lodash: 4.17.23
-      patch-console: 2.0.0
-      react: 18.3.1
-      react-reconciler: 0.29.2(react@18.3.1)
-      scheduler: 0.23.2
-      signal-exit: 3.0.7
-      slice-ansi: 6.0.0
-      stack-utils: 2.0.6
-      string-width: 5.1.2
-      type-fest: 0.12.0
-      widest-line: 4.0.1
-      wrap-ansi: 8.1.0
-      ws: 8.19.0
-      yoga-wasm-web: 0.3.3
-    optionalDependencies:
-      '@types/react': 18.3.28
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
 
   inline-style-parser@0.2.7: {}
 
@@ -6037,10 +5821,6 @@ snapshots:
     dependencies:
       binary-extensions: 2.3.0
 
-  is-ci@3.0.1:
-    dependencies:
-      ci-info: 3.9.0
-
   is-decimal@2.0.1: {}
 
   is-docker@3.0.0: {}
@@ -6050,8 +5830,6 @@ snapshots:
   is-extglob@2.1.1: {}
 
   is-fullwidth-code-point@3.0.0: {}
-
-  is-fullwidth-code-point@4.0.0: {}
 
   is-glob@4.0.3:
     dependencies:
@@ -6065,10 +5843,6 @@ snapshots:
 
   is-interactive@1.0.0: {}
 
-  is-lower-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
-
   is-node-process@1.2.0: {}
 
   is-number@7.0.0: {}
@@ -6078,10 +5852,6 @@ snapshots:
   is-stream@3.0.0: {}
 
   is-unicode-supported@0.1.0: {}
-
-  is-upper-case@2.0.2:
-    dependencies:
-      tslib: 2.8.1
 
   is-wsl@3.1.0:
     dependencies:
@@ -6982,8 +6752,6 @@ snapshots:
 
   parseurl@1.3.3: {}
 
-  patch-console@2.0.0: {}
-
   path-data-parser@0.1.0: {}
 
   path-key@3.1.1: {}
@@ -7080,12 +6848,6 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
-
-  react-reconciler@0.29.2(react@18.3.1):
-    dependencies:
-      loose-envify: 1.4.0
-      react: 18.3.1
-      scheduler: 0.23.2
 
   react@18.3.1:
     dependencies:
@@ -7264,14 +7026,10 @@ snapshots:
 
   resolve-from@4.0.0: {}
 
-  resolve-pkg-maps@1.0.0: {}
+  resolve-pkg-maps@1.0.0:
+    optional: true
 
   restore-cursor@3.1.0:
-    dependencies:
-      onetime: 5.1.2
-      signal-exit: 3.0.7
-
-  restore-cursor@4.0.0:
     dependencies:
       onetime: 5.1.2
       signal-exit: 3.0.7
@@ -7482,16 +7240,6 @@ snapshots:
 
   slash@5.1.0: {}
 
-  slice-ansi@5.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 4.0.0
-
-  slice-ansi@6.0.0:
-    dependencies:
-      ansi-styles: 6.2.3
-      is-fullwidth-code-point: 4.0.0
-
   source-map-js@1.2.1: {}
 
   source-map-support@0.5.21:
@@ -7512,10 +7260,6 @@ snapshots:
       wicked-good-xpath: 1.3.0
 
   sprintf-js@1.0.3: {}
-
-  stack-utils@2.0.6:
-    dependencies:
-      escape-string-regexp: 2.0.0
 
   stackback@0.0.2: {}
 
@@ -7689,6 +7433,7 @@ snapshots:
       get-tsconfig: 4.13.6
     optionalDependencies:
       fsevents: 2.3.3
+    optional: true
 
   twoslash-protocol@0.2.12: {}
 
@@ -7699,8 +7444,6 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
-
-  type-fest@0.12.0: {}
 
   type-fest@0.21.3: {}
 
@@ -8001,10 +7744,6 @@ snapshots:
 
   wicked-good-xpath@1.3.0: {}
 
-  widest-line@4.0.1:
-    dependencies:
-      string-width: 5.1.2
-
   wrap-ansi@6.2.0:
     dependencies:
       ansi-styles: 4.3.0
@@ -8023,8 +7762,6 @@ snapshots:
       string-width: 5.1.2
       strip-ansi: 7.1.2
 
-  ws@8.19.0: {}
-
   xtend@4.0.2: {}
 
   yaml@2.8.2: {}
@@ -8032,8 +7769,6 @@ snapshots:
   yargs-parser@21.1.1: {}
 
   yocto-queue@1.2.2: {}
-
-  yoga-wasm-web@0.3.3: {}
 
   zod-validation-error@3.5.4(zod@3.25.76):
     dependencies:


### PR DESCRIPTION
### Motivation
- Allow the MCP server to run both as a local STDIO process and as an HTTP-hosted JSON-RPC endpoint so teams can run it on a developer machine or deploy it to a remote server.
- Avoid protocol divergence by centralizing MCP JSON-RPC handling so both transports reuse the same behavior and tool dispatch.
- Make transport selection configurable via CLI flag or env and expose safe defaults for host/port when running HTTP.

### Description
- Added `McpProtocolHandler` that extracts MCP JSON-RPC logic (`initialize`, `tools/list`, `tools/call`) and tool dispatch into a reusable service. (`apps/mcp-server/src/mcp-protocol.handler.ts`)
- Implemented HTTP controller `POST /mcp` (`McpHttpController`) that uses `McpProtocolHandler` and returns JSON-RPC responses (including `-32600` for invalid payloads and `204` for notifications). (`apps/mcp-server/src/mcp-http.controller.ts`)
- Refactored `McpStdioServer` to delegate MCP requests and tool dispatch to `McpProtocolHandler`, preserving NDJSON/LSP framing and legacy NDJSON tool flow. (`apps/mcp-server/src/mcp-stdio.server.ts`)
- Added `transport` utilities and updated bootstrap `main.ts` to select transport via `--transport` or `MCP_SERVER_MODE` and to start Nest HTTP server with configurable `MCP_HTTP_HOST`/`MCP_HTTP_PORT`. (`apps/mcp-server/src/transport.ts`, `apps/mcp-server/src/main.ts`)
- Updated tests and scripts to the new DI shape and added tests for transport resolver and HTTP controller; updated docs to document running both STDIO and HTTP modes. (`apps/mcp-server/test/*`, `apps/mcp-server/scripts/*`, `README.md`, `apps/mcp-server/README.md`)

### Testing
- Ran the package test suite with `pnpm -C apps/mcp-server test` and all tests passed: `7 test files, 37 tests` (green).
- Added unit tests for `resolveTransport` and `McpHttpController` which passed as part of the suite. (`apps/mcp-server/test/transport.spec.ts`, `apps/mcp-server/test/mcp-http.controller.spec.ts`)
- Performed a manual HTTP smoke test by building and launching the server with `--transport http` and POSTing an `initialize` JSON-RPC request to `POST /mcp`, which returned the expected `initialize` response (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69959ea0f0d4832c90c7a2d73ed83e11)